### PR TITLE
Update draper.gemspec to allow activesupport versions 6.0.0 and above

### DIFF
--- a/draper.gemspec
+++ b/draper.gemspec
@@ -17,17 +17,17 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_dependency 'activesupport', '~> 5.0'
-  s.add_dependency 'actionpack', '~> 5.0'
-  s.add_dependency 'request_store', '~> 1.0'
-  s.add_dependency 'activemodel', '~> 5.0'
-  s.add_dependency 'activemodel-serializers-xml', '~> 1.0'
+  s.add_dependency 'activesupport', '>= 5.0'
+  s.add_dependency 'actionpack', '>= 5.0'
+  s.add_dependency 'request_store', '>= 1.0'
+  s.add_dependency 'activemodel', '>= 5.0'
+  s.add_dependency 'activemodel-serializers-xml', '>= 1.0'
 
   s.add_development_dependency 'ammeter'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'minitest-rails'
   s.add_development_dependency 'capybara'
-  s.add_development_dependency 'active_model_serializers', '~> 0.10'
+  s.add_development_dependency 'active_model_serializers', '>= 0.10'
   s.add_development_dependency 'rubocop'
 end


### PR DESCRIPTION
## Description
To allow Draper to be used with Rails 6 and above, the gemspec must allow activesupport versions higher than 5.x

## Testing
No changes other than gem dependency versions. Existing tests should suffice.
